### PR TITLE
Fix start project

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,6 +20,7 @@
         "max-lines": ["warn", {
             "max": 300, 
             "skipBlankLines": true
-        }]
+        }],
+        "linebreak-style": "off"
     }
 }

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
         "url-loader": "latest",
         "webpack": "3.11.0",
         "webpack-bundle-analyzer": "latest",
-        "webpack-dev-server": "latest",
+        "webpack-dev-server": "2.11.0",
         "webpack-log": "latest",
         "webpack-notifier": "latest",
         "webpack-sources": "latest"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,8 +102,10 @@ module.exports = {
             app.get('/service-worker.js', (request, response) => response.sendFile(SERVICE_WORKER_PATH));
         },
         compress: false,
+        contentBase: path.resolve(__dirname, 'source'),
         open: true,
         overlay: { warnings: false, errors: true },
+        watchContentBase: true,
     },
 
     entry: {


### PR DESCRIPTION
1. webpack-dev-server@latest не работает с webpack 3, рассчитан на webpack 4. Версия 2.11.0 решает проблему.
2. Добавлен content-base (+ watch), чтобы пересобирался html при сохранении файла. Работает только с файлами в корне (source).
3. Убрано eslint правило linebreak-style.